### PR TITLE
fix assets typo for assets folder

### DIFF
--- a/wp-content/themes/wp-hoob/scripts/html-generator/manifest.js
+++ b/wp-content/themes/wp-hoob/scripts/html-generator/manifest.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const manifestFile = path.resolve(__dirname, '../../public/assets/manifest.json');
-const manifestPath = path.resolve(__dirname, '../../public/assests');
+const manifestPath = path.resolve(__dirname, '../../public/assets');
 const manifestJSON = JSON.parse(fs.readFileSync(manifestFile));
 
 module.exports.asset = (asset) => {


### PR DESCRIPTION
This fix allows html generator link to the correct path for main css